### PR TITLE
use cppreference.com instead of cplusplus.com

### DIFF
--- a/docs/introduction/resources.md
+++ b/docs/introduction/resources.md
@@ -40,4 +40,4 @@
 - [OEIS 整数数列搜索引擎](https://oeis.org)
 - [Ubuntu Pastebin，可以用来分享代码](https://paste.ubuntu.com)
 - [uDebug 提供一些 OJ 题目的调试辅助](https://www.udebug.com)
-- [提供C++内语法的查询等 - C++ Reference](http://www.cplusplus.com/reference/)
+- [提供C++内语法的查询等 - cppreference.com](https://en.cppreference.com/w/)


### PR DESCRIPTION
The cplusplus.com is outdated. There's nothing about C++14/17/20.
The cppreference.com updates timely following drafting, and supports Chinese. It looks delicious.