### PR TITLE
remove render_math.js in netlify

### DIFF
--- a/netlify_build.sh
+++ b/netlify_build.sh
@@ -30,4 +30,3 @@ cp ./static/extra.js docs/_static/js/extra.js
 
 mkdocs build -v
 
-node --max_old_space_size=1024 netlify_math.js

--- a/netlify_build.sh
+++ b/netlify_build.sh
@@ -30,3 +30,5 @@ cp ./static/extra.js docs/_static/js/extra.js
 
 mkdocs build -v
 
+# uncomment this line to render mathjax on server side
+# node netlify_math.js


### PR DESCRIPTION
netlify 限制内存占用为 2G，现在用的这个 mathjax-node-page 占用内存太大，作者表示懒得改，最好等 mathjax-v3 出来。ref: https://github.com/pkra/mathjax-node-page/issues/72
解决办法或许可以考虑换用 wikipedia 渲染 mathjax 的方案，不过最近优先级并不高还没有仔细研究过