### PR TITLE
修复 testlib 相关的几处小错误并略作改进

### DIFF
--- a/docs/intro/testlib/checker.md
+++ b/docs/intro/testlib/checker.md
@@ -214,7 +214,7 @@ int main(int argc, char* argv[]) {
     int pos = ouf.readInt();
     int x =
         A[pos];  // 100% 会 RE。一定会有人输出 -42, 2147483456 或其他一些非法数字。
-                // ....
+                 // ....
     ```
 
     ##### 正面教材

--- a/docs/intro/testlib/general.md
+++ b/docs/intro/testlib/general.md
@@ -98,6 +98,6 @@ ensuref(s.length() % 2 == 0,
 
     全局函数 `::ensure/ensuref()` 多用于 generator 和 validator 中，如果检查失败将统一返回 `_fail`。
 
-    成员函数 `InStream::ensure/ensuref()` 一般用于判断选手和参考程序的输出是否合法。当 `Stream` 为 `ouf` 时，返回 `_wa`；为 `inf`（一般不使用）或 `ans` 时，返回 `_fail`。详见 [Checker - 编写 readAns 函数¶](/intro/testlib/checker/#_3)。
+    成员函数 `InStream::ensure/ensuref()` 一般用于判断选手和参考程序的输出是否合法。当 `Stream` 为 `ouf` 时，返回 `_wa`；为 `inf`（一般不使用）或 `ans` 时，返回 `_fail`。详见 [Checker - 编写 readAns 函数](/intro/testlib/checker/#_3)。
 
 **本文翻译并综合自[Testlib - Codeforces](https://codeforces.com/testlib)系列。`testlib.h` 的 GitHub 存储库为[MikeMirzayanov/testlib](https://github.com/MikeMirzayanov/testlib)。**

--- a/docs/intro/testlib/general.md
+++ b/docs/intro/testlib/general.md
@@ -2,8 +2,8 @@
 
 ## 通用状态
 
-| 结果                 | Testlib 别名   | 含义                                                              |
-| ------------------ | ------------ | --------------------------------------------------------------- |
+| 结果                 | Testlib 别名   | 含义                                                                                       |
+| ------------------ | ------------ | ---------------------------------------------------------------------------------------- |
 | Ok                 | `_ok`        | 答案正确。                                                                                    |
 | Wrong Answer       | `_wa`        | 答案错误。                                                                                    |
 | Presentation Error | `_pe`        | 答案格式错误。注意包括 Codeforces 在内的许多 OJ 并不区分 PE 和 WA。                                            |
@@ -87,11 +87,11 @@ ensuref(x_i != y_i, "Graph can't contain loops");
 
 ```cpp
 ensuref(s.length() % 2 == 0,
-    "String 's' should have even length, but s.length()=%d",
-    int(s.length()));
+        "String 's' should have even length, but s.length()=%d",
+        int(s.length()));
 ```
 
-方便地，我们可以使用 `ensure(x > y)`，如果条件不满足报错将为 `FAIL Condition failed: "x > y"`。
+方便地，我们可以使用 `ensure(x> y)`，如果条件不满足报错将为 `FAIL Condition failed: "x > y"`。
 
 ???+ warning
     注意全局与成员 `ensure/ensuref()` 的区别

--- a/docs/intro/testlib/general.md
+++ b/docs/intro/testlib/general.md
@@ -4,11 +4,11 @@
 
 | 结果                 | Testlib 别名   | 含义                                                              |
 | ------------------ | ------------ | --------------------------------------------------------------- |
-| Ok                 | `_ok`        | 答案正确。                                                           |
-| Wrong Answer       | `_wa`        | 答案错误。                                                           |
-| Presentation Error | `_pe`        | 答案格式错误。注意包括 Codeforces 在内的许多 OJ 并不区分 PE 和 WA。                   |
-| Partially Correct  | `_pc(score)` | 答案部分正确。仅限于有部分分的测试点，其中 `score` 为一个正整数，从 $0$（没分）到 $200$（可能的最大分数）。 |
-| Fail               | `_fail`      | 程序内部错误、标准输出有误或选手输出比标准输出更优，需要裁判 / 出题人关注。（也就是题目锅了）                |
+| Ok                 | `_ok`        | 答案正确。                                                                                    |
+| Wrong Answer       | `_wa`        | 答案错误。                                                                                    |
+| Presentation Error | `_pe`        | 答案格式错误。注意包括 Codeforces 在内的许多 OJ 并不区分 PE 和 WA。                                            |
+| Partially Correct  | `_pc(score)` | 答案部分正确。仅限于有部分分的测试点，其中 `score` 为一个正整数，从 $0$（没分）到 $100$（可能的最大分数）。                          |
+| Fail               | `_fail`      | validator 中表示输入不合法，不通过校验。<br>checker 中表示程序内部错误、标准输出有误或选手输出比标准输出更优，需要裁判 / 出题人关注。（也就是题目锅了） |
 
 通常用程序的返回值表明结果，但是也有一些其他方法：创建一个输出 xml 文件、输出信息到 stdout 或其他位置…… 这些都通过下方函数表中的 `quitf` 函数来完成。
 
@@ -16,9 +16,9 @@
 
 | 对象    | 含义    |
 | ----- | ----- |
-| `inf` | 标准输入流 |
+| `inf` | 输入文件流 |
 | `ouf` | 选手输出流 |
-| `ans` | 标准输出流 |
+| `ans` | 参考输出流 |
 
 ## 通用函数
 
@@ -26,10 +26,10 @@
 
 | 调用                                                                                              | 含义                                                  |
 | ----------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| `void registerTestlibCmd()`                                                                     | 注册 checker                                          |
-| `void registerInteraction()`                                                                    | 注册 interactor                                       |
-| `void registerValidation()`                                                                     | 注册 validator                                        |
-| `void registerGen()`                                                                            | 注册 generator                                        |
+| `void registerTestlibCmd(int argc, char* argv[])`                                               | 注册程序为 checker                                       |
+| `void registerInteraction(int argc, char* argv[])`                                              | 注册程序为 interactor                                    |
+| `void registerValidation()`                                                                     | 注册程序为 validator                                     |
+| `void registerGen(int argc, char* argv[], int randomGeneratorVersion)`                          | 注册程序为 generator<br>`randomGeneratorVersion` 推荐为 `1` |
 | `void quit(TResult verdict, string message)`/`void quitf(TResult verdict, string message, ...)` | 结束程序，返回 `verdict`，输出 `message`                      |
 | `void quitif(bool condition, TResult verdict, string message, ...)`                             | 如果 `condition` 成立，调用 `quitf(verdict, message, ...)` |
 
@@ -73,17 +73,31 @@
 
 ## 使用项别名
 
-推荐给 `readInt/readInteger/readLong/readDouble/readWord/readToken/readString/readLine` 等的有限制调用最后多传入一个 `string` 参数，即当前读入的项的别名，使报错易读。例如使用 `inf.readInt(1, 100, n)` 而非 `inf.readInt(1, 100)`，报错信息将为 `FAIL Integer parameter [name=n] equals to 0, violates the range [1, 100]`。
+推荐给 `readInt/readInteger/readLong/readDouble/readWord/readToken/readString/readLine` 等的有限制调用最后多传入一个 `string` 参数，即当前读入的项的别名，使报错易读。例如使用 `inf.readInt(1, 100, "n")` 而非 `inf.readInt(1, 100)`，报错信息将为 `FAIL Integer parameter [name=n] equals to 0, violates the range [1, 100]`。
 
-## 使用 `ensure/ensuref`
+## 使用 `ensure/ensuref()`
 
-这两个函数用于检查条件是否成立（类似于 `assert`）。例如检查 $x_i \neq y_i$，我们可以使用 `ensuref(x_i != y_i, "Graph can't contain loops")`。还可以使用 C 风格占位符如 `ensuref(s.length() % 2 == 0, "String's'should have even length, but s.length()=%d", int(s.length()))`。方便地，我们可以使用 `ensure(x> y)`，如果条件不满足报错将为 `FAIL Condition failed: "x > y"`。
+这两个函数用于检查条件是否成立（类似于 `assert()`）。例如检查 $x_i \neq y_i$，我们可以使用
+
+```cpp
+ensuref(x_i != y_i, "Graph can't contain loops");
+```
+
+还可以使用 C 风格占位符如
+
+```cpp
+ensuref(s.length() % 2 == 0,
+    "String 's' should have even length, but s.length()=%d",
+    int(s.length()));
+```
+
+方便地，我们可以使用 `ensure(x > y)`，如果条件不满足报错将为 `FAIL Condition failed: "x > y"`。
 
 ???+ warning
-    注意成员与非成员 `ensure/ensuref` 的区别
+    注意全局与成员 `ensure/ensuref()` 的区别
 
-    非成员函数仅用于题目内部检查，如标准输出是否合法（标准输出挂是真的有可能的）。如果检查失败将返回 `_fail`，而非 `_wa` 或 `pe`。
+    全局函数 `::ensure/ensuref()` 多用于 generator 和 validator 中，如果检查失败将统一返回 `_fail`。
 
-    成员函数仅用于判断选手输出是否合法。无论 `Stream` 为何（即 `inf` 和 `ans` 也如此），都将返回 `_wa`。
+    成员函数 `InStream::ensure/ensuref()` 一般用于判断选手和参考程序的输出是否合法。当 `Stream` 为 `ouf` 时，返回 `_wa`；为 `inf`（一般不使用）或 `ans` 时，返回 `_fail`。详见 [Checker 页面](./checker.md) 对于“`readAns` 模式”的说明。
 
 **本文翻译并综合自[Testlib - Codeforces](https://codeforces.com/testlib)系列。`testlib.h` 的 GitHub 存储库为[MikeMirzayanov/testlib](https://github.com/MikeMirzayanov/testlib)。**

--- a/docs/intro/testlib/general.md
+++ b/docs/intro/testlib/general.md
@@ -28,7 +28,7 @@
 | ----------------------------------------------------------------------------------------------- | --------------------------------------------------- |
 | `void registerTestlibCmd(int argc, char* argv[])`                                               | 注册程序为 checker                                       |
 | `void registerInteraction(int argc, char* argv[])`                                              | 注册程序为 interactor                                    |
-| `void registerValidation()`                                                                     | 注册程序为 validator                                     |
+| `void registerValidation()`/`void registerValidation(int argc, char* argv[])`                   | 注册程序为 validator                                     |
 | `void registerGen(int argc, char* argv[], int randomGeneratorVersion)`                          | 注册程序为 generator<br>`randomGeneratorVersion` 推荐为 `1` |
 | `void quit(TResult verdict, string message)`/`void quitf(TResult verdict, string message, ...)` | 结束程序，返回 `verdict`，输出 `message`                      |
 | `void quitif(bool condition, TResult verdict, string message, ...)`                             | 如果 `condition` 成立，调用 `quitf(verdict, message, ...)` |
@@ -98,6 +98,6 @@ ensuref(s.length() % 2 == 0,
 
     全局函数 `::ensure/ensuref()` 多用于 generator 和 validator 中，如果检查失败将统一返回 `_fail`。
 
-    成员函数 `InStream::ensure/ensuref()` 一般用于判断选手和参考程序的输出是否合法。当 `Stream` 为 `ouf` 时，返回 `_wa`；为 `inf`（一般不使用）或 `ans` 时，返回 `_fail`。详见 [Checker 页面](./checker.md) 对于“`readAns` 模式”的说明。
+    成员函数 `InStream::ensure/ensuref()` 一般用于判断选手和参考程序的输出是否合法。当 `Stream` 为 `ouf` 时，返回 `_wa`；为 `inf`（一般不使用）或 `ans` 时，返回 `_fail`。详见 [Checker - 编写 readAns 函数¶](/intro/testlib/checker/#_3)。
 
 **本文翻译并综合自[Testlib - Codeforces](https://codeforces.com/testlib)系列。`testlib.h` 的 GitHub 存储库为[MikeMirzayanov/testlib](https://github.com/MikeMirzayanov/testlib)。**


### PR DESCRIPTION
修复了 testlib 相关页面的几处错误，有些地方作了小改。关于 `InStream::ensuref()` 的说法，用当前版本的 testlib.h 做过实验，希望没有问题叭

改动比较杂，辛苦 reviewer 啦

----

首先，十分感谢你花时间来给 OI Wiki 开一个 Pull Request，下面是一些你可能需要知道的信息：

- 请在 commit 的时候写比较有意义的 commit message
- 请给 PR 起比较有意义的标题。
- 请在 PR 之前检查一下您的 PR 是否存在以下常见问题：（确认无问题后请将选项打钩 / 填为 `[x]`）
   * [x] 您的 MD 代码的书写格式，包括但不限于 **中文与英文之间、中文与阿拉伯数字、中文与 LaTeX 公式之间要有一个半角空格**，特别地，在中文全角符号与英文、阿拉伯数字、LaTeX 公式之间，**不需要**半角空格。（这个可以使用自动化工具辅助，比如 https://github.com/baurine/vscode-pangu)
   * [x] 对于 LaTeX 公式，请注意常见的问题，**一定要使用** `$\log$`、`$\min$`、`$\max$`、`$\gcd$` 等，而非 `$log$`、`$min$`、`$max$`、`$gcd$`。对于最小公倍数，请使用 `$\operatorname{lcm}$` 而非 `$lcm$`，省略号请使用 `$\cdots$`，叉乘请使用 `$\times$`，点乘请使用 `$\cdot$`。
   * [x] 所有公式中的希腊字母等特殊符号，请不要使用输入法的插入特殊符号功能，而应该使用对应的 LaTeX 公式符号。如 phi 大多数情况下应该使用 `$\varphi$` 而不是 `$\phi$`。
   * [x] 行间公式前后各要有一行空行。
   * [x] 对于目录中存在公式的情况，请使用 HTML 代码而非直接插入公式以避免双倍公式的问题，请参考[避免 ToC 中双倍公式的写法](https://oi-wiki.org/intro/faq/#_13))。
   * [x] NOI 系列赛英文名称请使用全大写，如 NOIP，其他比赛请与官方英文名称保持一致。

关于文档内容的基本格式和更多内容规范，可以查阅 [F.A.Q](https://oi-wiki.org/intro/faq/#_4)。
