### PR TITLE
fix: matrix-tree.md修锅

### DIFF
--- a/docs/misc/matrix-tree.md
+++ b/docs/misc/matrix-tree.md
@@ -9,13 +9,13 @@ Kirchhoff 矩阵树定理（简称矩阵树定理）解决了一张图的生成�
 设 $G$ 是一个有 $n$ 个顶点的无向图。定义度数矩阵 $D(G)$ 为：
 
 $$
-_{ii}(G) = \mathrm{deg}(i), D_{ij} = 0, i\neq j
+D_{ii}(G) = \mathrm{deg}(i), D_{ij} = 0, i\neq j
 $$
 
 设 $\#e(i,j)$ 为点 $i$ 与点 $j$ 相连的边数，并定义邻接矩阵 $A$ 为：
 
 $$
-A_{ij}(G)=\#e(i,j), i\neq j
+A_{ij}(G)=A_{ji}(G)=\#e(i,j), i\neq j
 $$
 
 定义 Laplace 矩阵（亦称 Kirchhoff 矩阵） $L$ 为：
@@ -34,7 +34,7 @@ $$
 D^{out}_{ii}(G) = \mathrm{deg^{out}}(i), D^{out}_{ij} = 0, i\neq j
 $$
 
-类似地定理入度矩阵 $D^{in}(G)$ 
+类似地定义入度矩阵 $D^{in}(G)$ 
 
 设 $\#e(i,j)$ 为点 $i$ 指向点 $j$ 的有向边数，并定义邻接矩阵 $A$ 为：
 
@@ -48,7 +48,11 @@ $$
 L^{out}(G) = D^{out}(G) - A(G)
 $$
 
-类似地定义入度 Laplace 矩阵 $L^{in}$ 。
+定义入度 Laplace 矩阵 $L^{in}$ 为：
+
+$$
+L^{in}(G) = D^{in}(G) - A(G)
+$$
 
 记图 $G$ 的以 $r$ 为根的所有根向树形图个数为 $t^{root}(G,r)$ 。所谓根向树形图，是说这张图的基图是一棵树，所有的边全部指向父亲。
 


### PR DESCRIPTION
修了一些小锅。

   * [x]  MD 代码的书写格式，包括但不限于 **中文与英文之间、中文与阿拉伯数字、中文与 LaTeX 公式之间要有一个半角空格**，特别地，在中文全角符号与英文、阿拉伯数字、LaTeX 公式之间，**不需要**半角空格。（这个可以使用自动化工具辅助，比如 https://github.com/baurine/vscode-pangu)
   * [x] 对于 LaTeX 公式，请注意常见的问题，**一定要使用** `$\log$`、`$\min$`、`$\max$`、`$\gcd$` 等，而非 `$log$`、`$min$`、`$max$`、`$gcd$`。对于最小公倍数，请使用 `$\operatorname{lcm}$` 而非 `$lcm$`，省略号请使用 `$\cdots$`，叉乘请使用 `$\times$`，点乘请使用 `$\cdot$`。
   * [x] 所有公式中的希腊字母等特殊符号，请不要使用输入法的插入特殊符号功能，而应该使用对应的 LaTeX 公式符号。如 phi 大多数情况下应该使用 `$\varphi$` 而不是 `$\phi$`。
   * [x] 行间公式前后各要有一行空行。
   * [x] 对于目录中存在公式的情况，请使用 HTML 代码而非直接插入公式以避免双倍公式的问题，请参考[避免 ToC 中双倍公式的写法](https://oi-wiki.org/intro/faq/#_13))。
   * [x] NOI 系列赛英文名称请使用全大写，如 NOIP，其他比赛请与官方英文名称保持一致。
